### PR TITLE
txn-id-bugfix

### DIFF
--- a/internal/iql/asyncmonitor/asyncmonitor.go
+++ b/internal/iql/asyncmonitor/asyncmonitor.go
@@ -33,6 +33,9 @@ type AsyncHttpMonitorPrimitive struct {
 	noStatus            bool
 }
 
+func (pr *AsyncHttpMonitorPrimitive) SetTxnId(id int) {
+}
+
 func (asm *AsyncHttpMonitorPrimitive) Execute(pc plan.IPrimitiveCtx) dto.ExecutorOutput {
 	if asm.Executor != nil {
 		if pc == nil {

--- a/internal/iql/drm/drm.go
+++ b/internal/iql/drm/drm.go
@@ -78,7 +78,7 @@ type PreparedStatementCtx struct {
 	TxnIdControlColName     string
 	InsIdControlColName     string
 	NonControlColumns       []ColumnMetadata
-	TxnCtrlCtrs             dto.TxnControlCounters
+	TxnCtrlCtrs             *dto.TxnControlCounters
 }
 
 func (ps PreparedStatementCtx) GetGCHousekeepingQueries() string {
@@ -97,7 +97,7 @@ type DRMConfig interface {
 	GenerateDDL(util.AnnotatedTabulation, int) []string
 	GetGolangValue(string) interface{}
 	GenerateInsertDML(util.AnnotatedTabulation, *txncounter.TxnCounterManager, int) (PreparedStatementCtx, error)
-	GenerateSelectDML(util.AnnotatedTabulation, dto.TxnControlCounters, sqlparser.SQLNode, *sqlparser.Where) (PreparedStatementCtx, error)
+	GenerateSelectDML(util.AnnotatedTabulation, *dto.TxnControlCounters, sqlparser.SQLNode, *sqlparser.Where) (PreparedStatementCtx, error)
 	ExecuteInsertDML(sqlengine.SQLEngine, *PreparedStatementCtx, map[string]interface{}) (sql.Result, error)
 	QueryDML(sqlengine.SQLEngine, *PreparedStatementCtx, map[string]interface{}) (*sql.Rows, error)
 }
@@ -268,7 +268,7 @@ func (dc *StaticDRMConfig) GenerateInsertDML(tabAnnotated util.AnnotatedTabulati
 			TxnIdControlColName:     txnIdColName,
 			InsIdControlColName:     insIdColName,
 			NonControlColumns:       columns,
-			TxnCtrlCtrs: dto.TxnControlCounters{
+			TxnCtrlCtrs: &dto.TxnControlCounters{
 				GenId:                 txnCtrMgr.GetCurrentGenerationId(),
 				SessionId:             txnCtrMgr.GetCurrentSessionId(),
 				TxnId:                 txnCtrMgr.GetNextTxnId(),
@@ -279,7 +279,7 @@ func (dc *StaticDRMConfig) GenerateInsertDML(tabAnnotated util.AnnotatedTabulati
 		nil
 }
 
-func (dc *StaticDRMConfig) GenerateSelectDML(tabAnnotated util.AnnotatedTabulation, txnCtrlCtrs dto.TxnControlCounters, node sqlparser.SQLNode, rewrittenWhere *sqlparser.Where) (PreparedStatementCtx, error) {
+func (dc *StaticDRMConfig) GenerateSelectDML(tabAnnotated util.AnnotatedTabulation, txnCtrlCtrs *dto.TxnControlCounters, node sqlparser.SQLNode, rewrittenWhere *sqlparser.Where) (PreparedStatementCtx, error) {
 	var q strings.Builder
 	var quotedColNames, quotedWhereColNames []string
 	var columns []ColumnMetadata

--- a/internal/iql/dto/control.go
+++ b/internal/iql/dto/control.go
@@ -3,3 +3,7 @@ package dto
 type TxnControlCounters struct {
 	GenId, SessionId, TxnId, InsertId, DiscoveryGenerationId int
 }
+
+func (tc *TxnControlCounters) SetTxnId(ti int) {
+	tc.TxnId = ti
+}

--- a/internal/iql/plan/plan.go
+++ b/internal/iql/plan/plan.go
@@ -23,6 +23,8 @@ type IPrimitive interface {
 	Execute(IPrimitiveCtx) dto.ExecutorOutput
 
 	GetPreparedStatementContext() *drm.PreparedStatementCtx
+
+	SetTxnId(int)
 }
 
 type Plan struct {

--- a/internal/iql/planbuilder/plan_builder.go
+++ b/internal/iql/planbuilder/plan_builder.go
@@ -178,7 +178,7 @@ func handleDelete(handlerCtx *handler.HandlerContext, node *sqlparser.Delete) (p
 		}
 		return primitiveGenerator.deleteExecutor(handlerCtx, node)
 	} else {
-		return primitivebuilder.NewHTTPRestPrimitive(nil, nil, nil), nil
+		return primitivebuilder.NewHTTPRestPrimitive(nil, nil, nil, nil), nil
 	}
 	return nil, nil
 }
@@ -192,7 +192,7 @@ func handleInsert(handlerCtx *handler.HandlerContext, node *sqlparser.Insert) (p
 		}
 		return primitiveGenerator.insertExecutor(handlerCtx, node, util.DefaultRowSort)
 	} else {
-		return primitivebuilder.NewHTTPRestPrimitive(nil, nil, nil), nil
+		return primitivebuilder.NewHTTPRestPrimitive(nil, nil, nil, nil), nil
 	}
 	return nil, nil
 }
@@ -206,7 +206,7 @@ func handleExec(handlerCtx *handler.HandlerContext, node *sqlparser.Exec) (plan.
 		}
 		return primitiveGenerator.execExecutor(handlerCtx, node)
 	}
-	return primitivebuilder.NewHTTPRestPrimitive(nil, nil, nil), nil
+	return primitivebuilder.NewHTTPRestPrimitive(nil, nil, nil, nil), nil
 }
 
 func handleShow(handlerCtx *handler.HandlerContext, node *sqlparser.Show) (plan.IPrimitive, error) {
@@ -265,6 +265,11 @@ func BuildPlanFromContext(handlerCtx *handler.HandlerContext) (*plan.Plan, error
 	planKey := handlerCtx.Query
 	if qp, ok := handlerCtx.LRUCache.Get(planKey); ok {
 		log.Infoln("retrieving query plan from cache")
+		pl, ok := qp.(*plan.Plan)
+		if ok {
+			pl.Instructions.SetTxnId(handlerCtx.TxnCounterMgr.GetNextTxnId())
+			return pl, nil
+		}
 		return qp.(*plan.Plan), nil
 	}
 	qPlan := &plan.Plan{

--- a/internal/iql/planbuilder/primitive_generator.go
+++ b/internal/iql/planbuilder/primitive_generator.go
@@ -440,6 +440,7 @@ func (pb *primitiveGenerator) insertExecutor(handlerCtx *handler.HandlerContext,
 		prov,
 		ex,
 		nil,
+		nil,
 	)
 	if !pb.PrimitiveBuilder.IsAwait() {
 		return insertPrimitive, nil
@@ -524,6 +525,7 @@ func (pb *primitiveGenerator) deleteExecutor(handlerCtx *handler.HandlerContext,
 	deletePrimitive := primitivebuilder.NewHTTPRestPrimitive(
 		prov,
 		ex,
+		nil,
 		nil,
 	)
 	if !pb.PrimitiveBuilder.IsAwait() {
@@ -612,6 +614,7 @@ func (pb *primitiveGenerator) execExecutor(handlerCtx *handler.HandlerContext, n
 	execPrimitive := primitivebuilder.NewHTTPRestPrimitive(
 		prov,
 		ex,
+		nil,
 		nil,
 	)
 	if !pb.PrimitiveBuilder.IsAwait() {

--- a/internal/iql/planbuilder/statement_analyzer.go
+++ b/internal/iql/planbuilder/statement_analyzer.go
@@ -798,6 +798,7 @@ func (p *primitiveGenerator) analyzeSelectDetail(handlerCtx *handler.HandlerCont
 	if err != nil {
 		return err
 	}
+	p.PrimitiveBuilder.SetTxnCtrlCtrs(insPsc.TxnCtrlCtrs)
 	for _, col := range cols {
 		// TODO: get rid of prefix garbage
 		foundSchemaPrefixed := schema.FindByPath(colPrefix + col.Name)

--- a/internal/iql/primitivebuilder/builder.go
+++ b/internal/iql/primitivebuilder/builder.go
@@ -38,9 +38,7 @@ type SingleSelect struct {
 	drmCfg                     drm.DRMConfig
 	insertPreparedStatementCtx *drm.PreparedStatementCtx
 	selectPreparedStatementCtx *drm.PreparedStatementCtx
-	generationId               int
-	txnId                      int
-	insertId                   int
+	txnCtrlCtr                 *dto.TxnControlCounters
 	rowSort                    func(map[string]map[string]interface{}) []string
 }
 
@@ -60,6 +58,7 @@ func NewSingleSelect(pb *PrimitiveBuilder, handlerCtx *handler.HandlerContext, t
 		drmCfg:                     handlerCtx.DrmConfig,
 		insertPreparedStatementCtx: insertCtx,
 		selectPreparedStatementCtx: selectCtx,
+		txnCtrlCtr:                 selectCtx.TxnCtrlCtrs,
 	}
 }
 
@@ -196,6 +195,7 @@ func (ss *SingleSelect) Build() error {
 		prov,
 		ex,
 		prep,
+		ss.txnCtrlCtr,
 	)
 	return nil
 }

--- a/internal/iql/primitivebuilder/primitive_builder.go
+++ b/internal/iql/primitivebuilder/primitive_builder.go
@@ -38,6 +38,7 @@ type PrimitiveBuilder struct {
 	columnOrder       []string
 	commentDirectives sqlparser.CommentDirectives
 	txnCounterManager *txncounter.TxnCounterManager
+	txnCtrlCtrs       *dto.TxnControlCounters
 
 	// per query -- SELECT only
 	insertValOnlyRows          map[int]map[int]interface{}
@@ -54,6 +55,10 @@ type PrimitiveBuilder struct {
 	symTab symtab.HashMapTreeSymTab
 
 	where *sqlparser.Where
+}
+
+func (pb *PrimitiveBuilder) SetTxnCtrlCtrs(tc *dto.TxnControlCounters) {
+	pb.txnCtrlCtrs = tc
 }
 
 func (pb *PrimitiveBuilder) GetSymbol(k interface{}) (symtab.SymTabEntry, error) {
@@ -228,9 +233,10 @@ func (pb PrimitiveBuilder) GetDRMConfig() drm.DRMConfig {
 }
 
 type HTTPRestPrimitive struct {
-	Provider   provider.IProvider
-	Executor   func(pc plan.IPrimitiveCtx) dto.ExecutorOutput
-	Preparator func() *drm.PreparedStatementCtx
+	Provider      provider.IProvider
+	Executor      func(pc plan.IPrimitiveCtx) dto.ExecutorOutput
+	Preparator    func() *drm.PreparedStatementCtx
+	TxnControlCtr *dto.TxnControlCounters
 }
 
 type MetaDataPrimitive struct {
@@ -242,6 +248,16 @@ type MetaDataPrimitive struct {
 type LocalPrimitive struct {
 	Executor   func(pc plan.IPrimitiveCtx) dto.ExecutorOutput
 	Preparator func() *drm.PreparedStatementCtx
+}
+
+func (pr *HTTPRestPrimitive) SetTxnId(id int) {
+	pr.TxnControlCtr.TxnId = id
+}
+
+func (pr *MetaDataPrimitive) SetTxnId(id int) {
+}
+
+func (pr *LocalPrimitive) SetTxnId(id int) {
 }
 
 func (pr *HTTPRestPrimitive) Execute(pc plan.IPrimitiveCtx) dto.ExecutorOutput {
@@ -293,11 +309,12 @@ func NewMetaDataPrimitive(provider provider.IProvider, executor func(pc plan.IPr
 	}
 }
 
-func NewHTTPRestPrimitive(provider provider.IProvider, executor func(pc plan.IPrimitiveCtx) dto.ExecutorOutput, preparator func() *drm.PreparedStatementCtx) *HTTPRestPrimitive {
+func NewHTTPRestPrimitive(provider provider.IProvider, executor func(pc plan.IPrimitiveCtx) dto.ExecutorOutput, preparator func() *drm.PreparedStatementCtx, txnCtrlCtr *dto.TxnControlCounters) *HTTPRestPrimitive {
 	return &HTTPRestPrimitive{
-		Provider:   provider,
-		Executor:   executor,
-		Preparator: preparator,
+		Provider:      provider,
+		Executor:      executor,
+		Preparator:    preparator,
+		TxnControlCtr: txnCtrlCtr,
 	}
 }
 

--- a/internal/iql/primitivebuilder/primitive_builder.go
+++ b/internal/iql/primitivebuilder/primitive_builder.go
@@ -251,7 +251,9 @@ type LocalPrimitive struct {
 }
 
 func (pr *HTTPRestPrimitive) SetTxnId(id int) {
-	pr.TxnControlCtr.TxnId = id
+	if pr.TxnControlCtr != nil {
+		pr.TxnControlCtr.TxnId = id
+	}
 }
 
 func (pr *MetaDataPrimitive) SetTxnId(id int) {

--- a/internal/iql/sqlengine/sqlengine.go
+++ b/internal/iql/sqlengine/sqlengine.go
@@ -67,7 +67,7 @@ type SQLEngine interface {
 	Query(string, ...interface{}) (*sql.Rows, error)
 	ExecFileLocal(string) error
 	ExecFile(string) error
-	GCCollectObsolete(dto.TxnControlCounters) error
+	GCCollectObsolete(*dto.TxnControlCounters) error
 	GCCollectObsoleteAll() error
 	GCCollectUnreachable() error
 	GCEnactFull() error
@@ -324,7 +324,7 @@ func (se SQLiteEngine) GCCollectObsoleteAll() error {
 	return se.collectObsolete()
 }
 
-func (se SQLiteEngine) GCCollectObsolete(tcc dto.TxnControlCounters) error {
+func (se SQLiteEngine) GCCollectObsolete(tcc *dto.TxnControlCounters) error {
 	return se.collectObsoleteQualified(tcc)
 }
 
@@ -340,7 +340,7 @@ func (se SQLiteEngine) collectObsolete() error {
 	return se.concertedQueryGen(cleanupObsoleteQuery)
 }
 
-func (se SQLiteEngine) collectObsoleteQualified(tcc dto.TxnControlCounters) error {
+func (se SQLiteEngine) collectObsoleteQualified(tcc *dto.TxnControlCounters) error {
 	return se.concertedQueryGen(cleanupObsoleteQualifiedQuery, tcc.GenId, tcc.SessionId, tcc.TxnId)
 }
 


### PR DESCRIPTION
Ensuring cached query plans do not re-use transaction IDs.